### PR TITLE
WIP - API spec updated to apply required changes from Commonalities r4.3

### DIFF
--- a/code/API_definitions/one-time-password-sms.yaml
+++ b/code/API_definitions/one-time-password-sms.yaml
@@ -28,6 +28,7 @@ info:
 
     <!-- CAMARA:MANDATORY:additional-error-responses:BEGIN -->
     # Additional CAMARA error responses
+    
     The list of error codes in this API specification is not exhaustive. Therefore the API specification MAY not document some non-mandatory error statuses as indicated in `CAMARA API Design Guide`.
 
     Please refer to the `CAMARA_common.yaml` of the Commonalities Release associated to this API version for a complete list of error responses. The applicable Commonalities Release can be identified in the `API Readiness Checklist` document associated to this API version.

--- a/code/API_definitions/one-time-password-sms.yaml
+++ b/code/API_definitions/one-time-password-sms.yaml
@@ -24,9 +24,8 @@ info:
     <!-- CAMARA:MANDATORY:authorization-and-authentication:END -->
 
     <!-- CAMARA:MANDATORY:identifying-phone-number-from-access-token:BEGIN -->
-    
     <!-- CAMARA:MANDATORY:identifying-phone-number-from-access-token:END -->
-    
+
     <!-- CAMARA:MANDATORY:additional-error-responses:BEGIN -->
     # Additional CAMARA error responses
     The list of error codes in this API specification is not exhaustive. Therefore the API specification MAY not document some non-mandatory error statuses as indicated in `CAMARA API Design Guide`.

--- a/code/API_definitions/one-time-password-sms.yaml
+++ b/code/API_definitions/one-time-password-sms.yaml
@@ -13,6 +13,7 @@ info:
     # Resources and Operations overview
     This API currently provides two endpoints, one to send an OTP to a given phone number and another to validate the code received as input.
 
+    <!-- CAMARA:MANDATORY:authorization-and-authentication:BEGIN -->
     # Authorization and authentication
 
     The "Camara Security and Interoperability Profile" provides details of how an API consumer requests an access token. Please refer to Identity and Consent Management (https://github.com/camaraproject/IdentityAndConsentManagement/) for the released version of the profile.
@@ -20,16 +21,24 @@ info:
     The specific authorization flows to be used will be agreed upon during the onboarding process, happening between the API consumer and the API provider, taking into account the declared purpose for accessing the API, whilst also being subject to the prevailing legal framework dictated by local legislation.
 
     In cases where personal data is processed by the API and users can exercise their rights through mechanisms such as opt-in and/or opt-out, the use of three-legged access tokens is mandatory. This ensures that the API remains in compliance with privacy regulations, upholding the principles of transparency and user-centric privacy-by-design.
+    <!-- CAMARA:MANDATORY:authorization-and-authentication:END -->
 
+    <!-- CAMARA:MANDATORY:additional-error-responses:BEGIN -->
     # Additional CAMARA error responses
-    The list of error codes in this API specification is not exhaustive. Therefore the API specification may not document some non-mandatory error statuses as indicated in `CAMARA API Design Guide`.
+    The list of error codes in this API specification is not exhaustive. Therefore the API specification MAY not document some non-mandatory error statuses as indicated in `CAMARA API Design Guide`.
 
     Please refer to the `CAMARA_common.yaml` of the Commonalities Release associated to this API version for a complete list of error responses. The applicable Commonalities Release can be identified in the `API Readiness Checklist` document associated to this API version.
 
     As a specific rule, error `501 - NOT_IMPLEMENTED` can be only a possible error response if it is explicitly documented in the API.
+    <!-- CAMARA:MANDATORY:additional-error-responses:END -->
 
+    <!-- CAMARA:MANDATORY:request-body-strictness:BEGIN -->
+    # Request body strictness
+
+    This API rejects requests with JSON request bodies that contain properties not declared in this specification, at any nesting level. Unknown properties result in a `400 INVALID_ARGUMENT` response.
+    <!-- CAMARA:MANDATORY:request-body-strictness:END -->
   version: wip
-  x-camara-commonalities: 0.6
+  x-camara-commonalities: 0.8.0
   license:
     name: Apache 2.0
     url: https://www.apache.org/licenses/LICENSE-2.0.html
@@ -123,21 +132,11 @@ paths:
 components:
   parameters:
     x-correlator:
-      name: x-correlator
-      in: header
-      description: Correlation id for the different services
-      schema:
-        $ref: "#/components/schemas/XCorrelator"
+      $ref: "../common/CAMARA_common.yaml#/components/parameters/x-correlator"
   headers:
     x-correlator:
-      description: Correlation id for the different services
-      schema:
-        $ref: "#/components/schemas/XCorrelator"
+      $ref: "../common/CAMARA_common.yaml#/components/headers/x-correlator"
   schemas:
-    XCorrelator:
-      type: string
-      pattern: ^[a-zA-Z0-9-_:;.\/<>{}]{0,256}$
-      example: "b4333c46-49c0-4f62-80d7-f0ef930f1c46"
     SendCodeBody:
       description: Structure to request sending a code to a phone number
       type: object
@@ -169,10 +168,7 @@ components:
         - authenticationId
         - code
     PhoneNumber:
-      description: A public identifier addressing a telephone subscription. In mobile networks it corresponds to the MSISDN (Mobile Station International Subscriber Directory Number). In order to be globally unique it has to be formatted in international format, according to E.164 standard, prefixed with '+'.
-      type: string
-      pattern: '^\+[1-9][0-9]{4,14}$'
-      example: '+346661113334'
+      $ref: "../common/CAMARA_common.yaml#/components/schemas/PhoneNumber"
     Message:
       type: string
       description: Message template used to compose the content of the SMS sent to the phone number. It must include the following label indicating where to include the short code `{{code}}`
@@ -190,26 +186,10 @@ components:
       maxLength: 10
       example: AJY3
     ErrorInfo:
-      description: Structure to describe error
-      type: object
-      required:
-        - status
-        - code
-        - message
-      properties:
-        status:
-          type: integer
-          description: HTTP response status code
-        code:
-          type: string
-          description: A human-readable code to describe the error
-        message:
-          type: string
-          description: A human-readable description of what the event represents
+      $ref: "../common/CAMARA_common.yaml#/components/schemas/ErrorInfo"
   securitySchemes:
     openId:
-      type: openIdConnect
-      openIdConnectUrl: https://example.com/.well-known/openid-configuration
+      $ref: "../common/CAMARA_common.yaml#/components/securitySchemes/openId"
   responses:
     Generic400:
       description: Problem with the client request
@@ -290,30 +270,7 @@ components:
                 code: ONE_TIME_PASSWORD_SMS.INVALID_OTP
                 message: The provided OTP is not valid for this authenticationId
     Generic401:
-      description: Authentication problem with the client request
-      headers:
-        x-correlator:
-          $ref: "#/components/headers/x-correlator"
-      content:
-        application/json:
-          schema:
-            allOf:
-              - $ref: "#/components/schemas/ErrorInfo"
-              - type: object
-                properties:
-                  status:
-                    enum:
-                      - 401
-                  code:
-                    enum:
-                      - UNAUTHENTICATED
-          examples:
-            GENERIC_401_UNAUTHENTICATED:
-              description: Request cannot be authenticated
-              value:
-                status: 401
-                code: UNAUTHENTICATED
-                message: Request not authenticated due to missing, invalid, or expired credentials.
+      $ref: "../common/CAMARA_common.yaml#/components/responses/Generic401"
     Generic403:
       description: Client does not have sufficient permission
       headers:
@@ -387,30 +344,7 @@ components:
                 code: ONE_TIME_PASSWORD_SMS.PHONE_NUMBER_BLOCKED
                 message: Phone_number is blocked to receive SMS due to any blocking business reason in the operator.
     Generic404:
-      description: Resource Not Found
-      headers:
-        x-correlator:
-          $ref: "#/components/headers/x-correlator"
-      content:
-        application/json:
-          schema:
-            allOf:
-              - $ref: "#/components/schemas/ErrorInfo"
-              - type: object
-                properties:
-                  status:
-                    enum:
-                      - 404
-                  code:
-                    enum:
-                      - NOT_FOUND
-          examples:
-            GENERIC_404_NOT_FOUND:
-              description: Resource is not found
-              value:
-                status: 404
-                code: NOT_FOUND
-                message: The specified resource is not found.
+      $ref: "../common/CAMARA_common.yaml#/components/responses/Generic404"
     Generic429:
       description: Either out of resource quota or reaching rate limiting
       headers:

--- a/code/API_definitions/one-time-password-sms.yaml
+++ b/code/API_definitions/one-time-password-sms.yaml
@@ -23,8 +23,6 @@ info:
     In cases where personal data is processed by the API and users can exercise their rights through mechanisms such as opt-in and/or opt-out, the use of three-legged access tokens is mandatory. This ensures that the API remains in compliance with privacy regulations, upholding the principles of transparency and user-centric privacy-by-design.
     <!-- CAMARA:MANDATORY:authorization-and-authentication:END -->
 
-    <!-- CAMARA:MANDATORY:identifying-phone-number-from-access-token:BEGIN -->
-    <!-- CAMARA:MANDATORY:identifying-phone-number-from-access-token:END -->
 
     <!-- CAMARA:MANDATORY:additional-error-responses:BEGIN -->
     # Additional CAMARA error responses

--- a/code/API_definitions/one-time-password-sms.yaml
+++ b/code/API_definitions/one-time-password-sms.yaml
@@ -23,6 +23,10 @@ info:
     In cases where personal data is processed by the API and users can exercise their rights through mechanisms such as opt-in and/or opt-out, the use of three-legged access tokens is mandatory. This ensures that the API remains in compliance with privacy regulations, upholding the principles of transparency and user-centric privacy-by-design.
     <!-- CAMARA:MANDATORY:authorization-and-authentication:END -->
 
+    <!-- CAMARA:MANDATORY:identifying-phone-number-from-access-token:BEGIN -->
+    
+    <!-- CAMARA:MANDATORY:identifying-phone-number-from-access-token:END -->
+    
     <!-- CAMARA:MANDATORY:additional-error-responses:BEGIN -->
     # Additional CAMARA error responses
     The list of error codes in this API specification is not exhaustive. Therefore the API specification MAY not document some non-mandatory error statuses as indicated in `CAMARA API Design Guide`.

--- a/code/API_definitions/one-time-password-sms.yaml
+++ b/code/API_definitions/one-time-password-sms.yaml
@@ -28,7 +28,7 @@ info:
 
     <!-- CAMARA:MANDATORY:additional-error-responses:BEGIN -->
     # Additional CAMARA error responses
-    
+
     The list of error codes in this API specification is not exhaustive. Therefore the API specification MAY not document some non-mandatory error statuses as indicated in `CAMARA API Design Guide`.
 
     Please refer to the `CAMARA_common.yaml` of the Commonalities Release associated to this API version for a complete list of error responses. The applicable Commonalities Release can be identified in the `API Readiness Checklist` document associated to this API version.


### PR DESCRIPTION
Updated references to common components and error responses, improved request body strictness, and adjusted version number.


#### What type of PR is this?

Add one of the following kinds:

* enhancement/feature
* subproject management



#### What this PR does / why we need it:

This PR updates the OTPValidation API specification and test definitions to align with [CAMARA Commonalities r4.3](https://github.com/camaraproject/Commonalities/releases/tag/r4.3) (Commonalities 0.8.0).

**API specification (cone-time-password-sms.yaml)**

- Updated x-camara-commonalities version from 0.6 to 0.8.0
- Replaced inline definitions for x-correlator header/parameter, PhoneNumber, and ErrorInfo with $ref to CAMARA_common.yaml, removing duplicated schema definitions
- Replaced inline Generic401 response with $ref to CAMARA_common.yaml
- Removed unused XCorrelator schema component (rule S-211)
- Added mandatory CAMARA info.description section markers (authorization-and-authentication, additional-error-responses, request-body-strictness)



#### Which issue(s) this PR fixes:

<!-- Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`. -->

Fixes #133 

#### Special notes for reviewers:



#### Changelog input

```
 release-note

```

#### Additional documentation 

This section can be blank.



```
docs

```
