### PR TITLE
Replace 403 use to 422/429 to be aligned with CAMARA logic

### DIFF
--- a/code/API_definitions/one-time-password-sms.yaml
+++ b/code/API_definitions/one-time-password-sms.yaml
@@ -88,11 +88,13 @@ paths:
         '401':
           $ref: '#/components/responses/Generic401'
         '403':
-          $ref: '#/components/responses/SendCodeForbiddenError403'
+          $ref: '#/components/responses/Generic403'
         '404':
           $ref: '#/components/responses/Generic404'
+        '422':
+          $ref: '#/components/responses/SendCodeUnprocessableEntity422'
         '429':
-          $ref: '#/components/responses/Generic429'
+          $ref: '#/components/responses/SendCodeQuotaLimit429'
       security:
         - openId:
             - one-time-password-sms:send-validate
@@ -299,57 +301,44 @@ components:
                 status: 403
                 code: PERMISSION_DENIED
                 message: Client does not have sufficient permissions to perform this action.
-    SendCodeForbiddenError403:
+    SendCodeUnprocessableEntity422:
       description: |-
-        Client does not have sufficient permissions to perform this action.
-        In addition to regular scenario of `PERMISSION_DENIED`, another scenarios may exist:
-          - Too many code requests were sent (`{"code": "ONE_TIME_PASSWORD_SMS.MAX_OTP_CODES_EXCEEDED","message": "Too many OTPs have been requested for this MSISDN. Try later."}`)
+        Unprocessable content:
           - The given phoneNumber can't receive an SMS due to business reasons in the operator, e.g. fraud, receiving SMS is not supported, etc (`{"code": "ONE_TIME_PASSWORD_SMS.PHONE_NUMBER_NOT_ALLOWED","message": "Phone_number can't receive an SMS due to business reasons in the operator."}`)
           - The given phoneNumber is blocked to receive SMS due to any blocking business reason in the operator (`{"code": "ONE_TIME_PASSWORD_SMS.PHONE_NUMBER_BLOCKED","message": "Phone_number is blocked to receive SMS due to any blocking business reason in the operator."}`)
       headers:
         x-correlator:
-          $ref: "#/components/headers/x-correlator"
+          $ref: "../common/CAMARA_common.yaml#/components/headers/x-correlator"
       content:
         application/json:
           schema:
             allOf:
-              - $ref: "#/components/schemas/ErrorInfo"
+              - $ref: "../common/CAMARA_common.yaml#/components/schemas/ErrorInfo"
               - type: object
                 properties:
                   status:
                     enum:
-                      - 403
+                      - 422
                   code:
                     enum:
-                      - PERMISSION_DENIED
-                      - ONE_TIME_PASSWORD_SMS.MAX_OTP_CODES_EXCEEDED
                       - ONE_TIME_PASSWORD_SMS.PHONE_NUMBER_NOT_ALLOWED
                       - ONE_TIME_PASSWORD_SMS.PHONE_NUMBER_BLOCKED
           examples:
-            GENERIC_403_PERMISSION_DENIED:
+            OTP_VALIDATION_422_PHONE_NUMBER_NOT_ALLOWED:
               value:
-                status: 403
-                code: PERMISSION_DENIED
-                message: Client does not have sufficient permissions to perform this action
-            OTP_VALIDATION_403_MAX_OTP_CODES_EXCEEDED:
-              value:
-                status: 403
-                code: ONE_TIME_PASSWORD_SMS.MAX_OTP_CODES_EXCEEDED
-                message: Too many OTPs have been requested for this MSISDN. Try later.
-            OTP_VALIDATION_403_PHONE_NUMBER_NOT_ALLOWED:
-              value:
-                status: 403
+                status: 422
                 code: ONE_TIME_PASSWORD_SMS.PHONE_NUMBER_NOT_ALLOWED
                 message: Phone_number can't receive an SMS due to business reasons in the operator.
-            OTP_VALIDATION_403_PHONE_NUMBER_BLOCKED:
+            OTP_VALIDATION_422_PHONE_NUMBER_BLOCKED:
               value:
-                status: 403
+                status: 422
                 code: ONE_TIME_PASSWORD_SMS.PHONE_NUMBER_BLOCKED
                 message: Phone_number is blocked to receive SMS due to any blocking business reason in the operator.
     Generic404:
       $ref: "../common/CAMARA_common.yaml#/components/responses/Generic404"
     Generic429:
-      description: Either out of resource quota or reaching rate limiting
+      description: |-
+        Either out of resource quota or reaching rate limiting
       headers:
         x-correlator:
           $ref: "#/components/headers/x-correlator"
@@ -380,3 +369,44 @@ components:
                 status: 429
                 code: TOO_MANY_REQUESTS
                 message: Rate limit reached.
+    SendCodeQuotaLimit429:
+      description: |-
+        Either out of resource quota or reaching rate limiting
+        In addition to regular scenario of `QUOTA_EXCEEDED` or `TOO_MANY_REQUESTS`, another scenario may exist:
+          - Too many code requests were sent (`{"code": "ONE_TIME_PASSWORD_SMS.MAX_OTP_CODES_EXCEEDED","message": "Too many OTPs have been requested for this MSISDN. Try later."}`)
+      headers:
+        x-correlator:
+          $ref: "#/components/headers/x-correlator"
+      content:
+        application/json:
+          schema:
+            allOf:
+              - $ref: "#/components/schemas/ErrorInfo"
+              - type: object
+                properties:
+                  status:
+                    enum:
+                      - 429
+                  code:
+                    enum:
+                      - QUOTA_EXCEEDED
+                      - TOO_MANY_REQUESTS
+                      - ONE_TIME_PASSWORD_SMS.MAX_OTP_CODES_EXCEEDED
+          examples:
+            GENERIC_429_QUOTA_EXCEEDED:
+              description: Request is rejected due to exceeding a business quota limit
+              value:
+                status: 429
+                code: QUOTA_EXCEEDED
+                message: Out of resource quota.
+            GENERIC_429_TOO_MANY_REQUESTS:
+              description: Access to the API has been temporarily blocked due to rate or spike arrest limits being reached
+              value:
+                status: 429
+                code: TOO_MANY_REQUESTS
+                message: Rate limit reached.
+            OTP_VALIDATION_429_MAX_OTP_CODES_EXCEEDED:
+              value:
+                status: 429
+                code: ONE_TIME_PASSWORD_SMS.MAX_OTP_CODES_EXCEEDED
+                message: Too many OTPs have been requested for this MSISDN. Try later.

--- a/code/Test_definitions/one-time-password-sms-sendCode.feature
+++ b/code/Test_definitions/one-time-password-sms-sendCode.feature
@@ -143,60 +143,50 @@ Feature: one-time-password-sms, vwip - Operation sendCode
     And the response header "x-correlator" has same value as the request header "x-correlator"
 
 ###########################
-#  403 errors for send-code
+#  422 errors for send-code
 ###########################
 
-  @OTPvalidationAPI_03_send_code_max_otp_code
-  Scenario: Validation for failed scenario too many codes have been requested
-    Given the request body property "$.phoneNumber" is set to config_var: "phone_number"
-    And the request body property "$.message" is set to config_var: "message"
-    And (config_var:"max_send"-1) of send-code requests for this phone number has been submitted
-    When the HTTP "POST" request is sent
-    Then the response property "$.status" is 403
-    And the response property "$.code" is "ONE_TIME_PASSWORD_SMS.MAX_OTP_CODES_EXCEEDED"
-    And the response property "$.message" contains a user friendly text
-    And the response header "x-correlator" has same value as the request header "x-correlator"
-
-  @OTPvalidationAPI_04_send_code_phone_number_not_allowed
+  @OTPvalidationAPI_422_01_send_code_phone_number_not_allowed
   Scenario: Validation for failed scenario for a phone number that cannot receive SMS
     Given the request body property "$.phoneNumber" is set to a phone number that cannot receive SMS
     And the request body property "$.message" is set to config_var: "message"
     When the HTTP "POST" request is sent
-    Then the response property "$.status" is 403
+    Then the response property "$.status" is 422
     And the response property "$.code" is "ONE_TIME_PASSWORD_SMS.PHONE_NUMBER_NOT_ALLOWED"
     And the response property "$.message" contains a user friendly text
     And the response header "x-correlator" has same value as the request header "x-correlator"
 
-  @OTPvalidationAPI_05_send_code_phone_number_not_allowed_3
+  @OTPvalidationAPI_422_02_send_code_phone_number_not_allowed_2
   Scenario: Validation for failed scenario for a phone number that target a landline
     Given the request body property "$.phoneNumber" is set to a phone number that target a landline
     And the request body property "$.message" is set to config_var: "message"
     When the HTTP "POST" request is sent
-    Then the response property "$.status" is 403
+    Then the response property "$.status" is 422
     And the response property "$.code" is "ONE_TIME_PASSWORD_SMS.PHONE_NUMBER_NOT_ALLOWED"
     And the response property "$.message" contains a user friendly text
     And the response header "x-correlator" has same value as the request header "x-correlator"
 
-  @OTPvalidationAPI_06_send_code_phone_number_blocked
+  @OTPvalidationAPI_422_03_send_code_phone_number_blocked
   Scenario: Validation for failed scenario for a phone number that block SMS reception
     Given the request body property "$.phoneNumber" is set to a phone number that that has an active SMS barring
     And the request body property "$.message" is set to config_var: "message"
     When the HTTP "POST" request is sent
-    Then the response property "$.status" is 403
+    Then the response property "$.status" is 422
     And the response property "$.code" is "ONE_TIME_PASSWORD_SMS.PHONE_NUMBER_BLOCKED"
     And the response property "$.message" contains a user friendly text
     And the response header "x-correlator" has same value as the request header "x-correlator"
 
 ###########################
-#  404 errors for send-code
+#  429 errors for send-code
 ###########################
 
-  @OTPvalidationAPI_404.1_send_code_phone_number_not_belong_to_operator
-  Scenario: Validation for failed scenario for a phone number that did not belong to the operator
-    Given the request body property "$.phoneNumber" is set to a phone number that did not belong to the operator
+  @OTPvalidationAPI_429_01_send_code_max_otp_code
+  Scenario: Validation for failed scenario too many codes have been requested
+    Given the request body property "$.phoneNumber" is set to config_var: "phone_number"
     And the request body property "$.message" is set to config_var: "message"
+    And (config_var:"max_send"-1) of send-code requests for this phone number has been submitted
     When the HTTP "POST" request is sent
-    Then the response property "$.status" is 404
-    And the response property "$.code" is "NOT_FOUND"
+    Then the response property "$.status" is 429
+    And the response property "$.code" is "ONE_TIME_PASSWORD_SMS.MAX_OTP_CODES_EXCEEDED"
     And the response property "$.message" contains a user friendly text
     And the response header "x-correlator" has same value as the request header "x-correlator"


### PR DESCRIPTION
#### What type of PR is this?

Add one of the following kinds:

* correction

#### What this PR does / why we need it:

Change http code:

ONE_TIME_PASSWORD_SMS.MAX_OTP_CODES_EXCEEDED **was 403, now 429**
ONE_TIME_PASSWORD_SMS.PHONE_NUMBER_NOT_ALLOWED **was 403, now 422**
ONE_TIME_PASSWORD_SMS.PHONE_NUMBER_BLOCKED **was 403, now 422**


#### Which issue(s) this PR fixes:

<!-- Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`. -->

Fixes #123 

#### Special notes for reviewers:

This is a **breaking change**  modification

#### Changelog input

```
 release-note
Changed error code for following UC:
- When too many send-code requested code 429 ONE_TIME_PASSWORD_SMS.MAX_OTP_CODES_EXCEEDED  is send instead of 403
- When the send-code is performed for a number not allowed (like a landline number) 422 ONE_TIME_PASSWORD_SMS.PHONE_NUMBER_NOT_ALLOWED is send instead of 403
- When the send-code is performed for a number blocked 422 ONE_TIME_PASSWORD_SMS.BLOCKED is send instead of 403

```

#### Additional documentation 

This section can be blank.



```
docs

```
