### PR TITLE
fix: correct typos in one-time-password-sms.yaml descriptions

### DIFF
--- a/code/API_definitions/one-time-password-sms.yaml
+++ b/code/API_definitions/one-time-password-sms.yaml
@@ -4,7 +4,7 @@ info:
   description: |-
     Service API to send short-lived OTPs (one time passwords) to a phone number via SMS and validate it afterwards, in order to verify the phone number as a proof of possession.
 
-    # Relevant  Definitions and concepts
+    # Relevant Definitions and concepts
     - **OTP**: *One Time password* is a one-time authorization code that is valid for only one login session or transaction.
 
     # API Functionality
@@ -159,7 +159,7 @@ components:
       required:
         - authenticationId
     ValidateCodeBody:
-      description: Strcuture to request code verification
+      description: Structure to request code verification
       type: object
       properties:
         authenticationId:
@@ -185,7 +185,7 @@ components:
       example: ea0840f3-3663-4149-bd10-c7c6b8912105
     Code:
       type: string
-      description: temporal, short code to be validated
+      description: temporary, short code to be validated
       maxLength: 10
       example: AJY3
     ErrorInfo:
@@ -221,7 +221,7 @@ components:
                 message: Client specified an invalid argument, request body or query param.
     ValidateCodeBadRequestError400:
       description: |-
-        Problem with the client request. In addition to regular scenario of `INVALID_ARGUMENT`, another scenarios may exist:
+        Problem with the client request. In addition to regular scenario of `INVALID_ARGUMENT`, other scenarios may exist:
           - Too many unsuccessful attempts (`{"code": "ONE_TIME_PASSWORD_SMS.VERIFICATION_FAILED","message": "The maximum number of attempts for this authenticationId was exceeded without providing a valid OTP"}`)
           - Expired authenticationId (`{"code": "ONE_TIME_PASSWORD_SMS.VERIFICATION_EXPIRED","message": "The authenticationId is no longer valid"}`)
           - OTP is not valid for the provided authenticationId (`{"code": "ONE_TIME_PASSWORD_SMS.INVALID_OTP","message": "The provided OTP is not valid for this authenticationId"}`)
@@ -302,7 +302,7 @@ components:
     SendCodeForbiddenError403:
       description: |-
         Client does not have sufficient permissions to perform this action.
-        In addition to regular scenario of `PERMISSION_DENIED`, another scenarios may exist:
+        In addition to regular scenario of `PERMISSION_DENIED`, other scenarios may exist:
           - Too many code requests were sent (`{"code": "ONE_TIME_PASSWORD_SMS.MAX_OTP_CODES_EXCEEDED","message": "Too many OTPs have been requested for this MSISDN. Try later."}`)
           - The given phoneNumber can't receive an SMS due to business reasons in the operator, e.g. fraud, receiving SMS is not supported, etc (`{"code": "ONE_TIME_PASSWORD_SMS.PHONE_NUMBER_NOT_ALLOWED","message": "Phone_number can't receive an SMS due to business reasons in the operator."}`)
           - The given phoneNumber is blocked to receive SMS due to any blocking business reason in the operator (`{"code": "ONE_TIME_PASSWORD_SMS.PHONE_NUMBER_BLOCKED","message": "Phone_number is blocked to receive SMS due to any blocking business reason in the operator."}`)


### PR DESCRIPTION
#### What type of PR is this?

* cleanup

#### What this PR does / why we need it:

Fixes typos in the descriptions of `one-time-password-sms.yaml`. These are in the API definition, so out of scope for #146, which only touched `code/Test_definitions/*.feature`.

- `Strcuture` -> `Structure` (`ValidateCodeBody` description)
- double space in `Relevant  Definitions`
- `temporal` -> `temporary` (`Code` description)
- `another scenarios` -> `other scenarios` (two 4xx response descriptions)

No functional or schema change.

#### Which issue(s) this PR fixes:

Part of #145

#### Special notes for reviewers:

No breaking change. Text-only fix.

#### Changelog input

```
 release-note
- Fix typos in one-time-password-sms.yaml descriptions
```

#### Additional documentation

This section can be blank.

```
docs

```
