### PR TITLE
Bump one-time-password-sms release plan to rc

### DIFF
--- a/release-plan.yaml
+++ b/release-plan.yaml
@@ -20,7 +20,7 @@ repository:
 
   # Release type being prepared (must be set before release can be triggered)
   # Options: none | pre-release-alpha | pre-release-rc | public-release | maintenance-release
-  target_release_type: pre-release-alpha
+  target_release_type: pre-release-rc
 
 # Dependencies on Commonalities and ICM releases
 # Update per ReleaseManagement requirements for each release cycle
@@ -34,7 +34,7 @@ dependencies:
 apis:
   - api_name: one-time-password-sms
     target_api_version: 2.0.0
-    target_api_status: alpha
+    target_api_status: rc
     main_contacts:
       - bigludo7
       - fernandopradocabrillo


### PR DESCRIPTION
#### What type of PR is this?

* subproject management

#### What this PR does / why we need it:

Bumps `release-plan.yaml` from `pre-release-alpha` to `pre-release-rc` for `one-time-password-sms` (Sync26 r4.1), per the release readiness checklist in #138.

#### Which issue(s) this PR fixes:

Part of #138

#### Special notes for reviewers:

No spec change. A companion PR addresses the #144 error-model findings; rc also expects Commonalities compliance and basic test cases per the readiness checklist.

#### Changelog input

```
 release-note
NONE
```

#### Additional documentation

This section can be blank.

```
docs

```
