### PR TITLE
Align error model and test coverage with issue #144 findings

### DIFF
--- a/code/API_definitions/one-time-password-sms.yaml
+++ b/code/API_definitions/one-time-password-sms.yaml
@@ -90,7 +90,7 @@ paths:
         '403':
           $ref: '#/components/responses/SendCodeForbiddenError403'
         '404':
-          $ref: '#/components/responses/Generic404'
+          $ref: '#/components/responses/SendCodeIdentifierNotFound404'
         '429':
           $ref: '#/components/responses/Generic429'
       security:
@@ -125,7 +125,7 @@ paths:
         '403':
           $ref: '#/components/responses/Generic403'
         '404':
-          $ref: '#/components/responses/Generic404'
+          $ref: '#/components/responses/SendCodeNotFound404'
         '429':
           $ref: '#/components/responses/Generic429'
       security:
@@ -180,7 +180,7 @@ components:
     AuthenticationId:
       type: string
       description: unique id of the verification attempt the code belongs to.
-      pattern: ^[a-zA-Z0-9-]{0,36}$
+      pattern: ^[a-zA-Z0-9-]{1,36}$
       maxLength: 36
       example: ea0840f3-3663-4149-bd10-c7c6b8912105
     Code:
@@ -346,8 +346,56 @@ components:
                 status: 403
                 code: ONE_TIME_PASSWORD_SMS.PHONE_NUMBER_BLOCKED
                 message: Phone_number is blocked to receive SMS due to any blocking business reason in the operator.
-    Generic404:
-      $ref: "../common/CAMARA_common.yaml#/components/responses/Generic404"
+    SendCodeIdentifierNotFound404:
+      description: Not found
+      headers:
+        x-correlator:
+          $ref: "#/components/headers/x-correlator"
+      content:
+        application/json:
+          schema:
+            allOf:
+              - $ref: "#/components/schemas/ErrorInfo"
+              - type: object
+                properties:
+                  status:
+                    enum:
+                      - 404
+                  code:
+                    enum:
+                      - IDENTIFIER_NOT_FOUND
+          examples:
+            GENERIC_404_IDENTIFIER_NOT_FOUND:
+              description: Some identifier cannot be matched to a device
+              value:
+                status: 404
+                code: IDENTIFIER_NOT_FOUND
+                message: Device identifier not found.
+    SendCodeNotFound404:
+      description: Not found
+      headers:
+        x-correlator:
+          $ref: "#/components/headers/x-correlator"
+      content:
+        application/json:
+          schema:
+            allOf:
+              - $ref: "#/components/schemas/ErrorInfo"
+              - type: object
+                properties:
+                  status:
+                    enum:
+                      - 404
+                  code:
+                    enum:
+                      - NOT_FOUND
+          examples:
+            GENERIC_404_NOT_FOUND:
+              description: Resource is not found
+              value:
+                status: 404
+                code: NOT_FOUND
+                message: The specified resource is not found.
     Generic429:
       description: Either out of resource quota or reaching rate limiting
       headers:

--- a/code/API_definitions/one-time-password-sms.yaml
+++ b/code/API_definitions/one-time-password-sms.yaml
@@ -10,6 +10,8 @@ info:
     # API Functionality
     It enables a Service Provider (SP) to send an OTP code by SMS and validate it to verify the phone number (MSISDN) as a proof of possession.
 
+    This API is designed for two-legged access tokens only: `phoneNumber` is provided explicitly in the request as the subject of the proof-of-possession check, rather than derived from a three-legged access token.
+
     # Resources and Operations overview
     This API currently provides two endpoints, one to send an OTP to a given phone number and another to validate the code received as input.
 
@@ -125,7 +127,7 @@ paths:
         '403':
           $ref: '#/components/responses/Generic403'
         '404':
-          $ref: '#/components/responses/SendCodeNotFound404'
+          $ref: '#/components/responses/ValidateCodeNotFound404'
         '429':
           $ref: '#/components/responses/Generic429'
       security:
@@ -150,6 +152,7 @@ components:
       required:
         - message
         - phoneNumber
+      additionalProperties: false
     SendCodeResponse:
       description: Structure to provide authentication identifier
       type: object
@@ -169,6 +172,7 @@ components:
       required:
         - authenticationId
         - code
+      additionalProperties: false
     PhoneNumber:
       $ref: "../common/CAMARA_common.yaml#/components/schemas/PhoneNumber"
     Message:
@@ -241,17 +245,10 @@ components:
                   code:
                     enum:
                       - INVALID_ARGUMENT
-                      - OUT_OF_RANGE
                       - ONE_TIME_PASSWORD_SMS.VERIFICATION_FAILED
                       - ONE_TIME_PASSWORD_SMS.VERIFICATION_EXPIRED
                       - ONE_TIME_PASSWORD_SMS.INVALID_OTP
           examples:
-            GENERIC_400_OUT_OF_RANGE:
-              description: Out of Range. Specific Syntax Exception used when a given field has a pre-defined range or a invalid filter criteria combination is requested
-              value:
-                status: 400
-                code: OUT_OF_RANGE
-                message: Client specified an invalid range.
             GENERIC_400_INVALID_ARGUMENT:
               value:
                 status: 400
@@ -371,7 +368,7 @@ components:
                 status: 404
                 code: IDENTIFIER_NOT_FOUND
                 message: Device identifier not found.
-    SendCodeNotFound404:
+    ValidateCodeNotFound404:
       description: Not found
       headers:
         x-correlator:

--- a/code/Test_definitions/one-time-password-sms-sendCode.feature
+++ b/code/Test_definitions/one-time-password-sms-sendCode.feature
@@ -127,6 +127,19 @@ Feature: one-time-password-sms, vwip - Operation sendCode
     And the response property "$.code" is "INVALID_ARGUMENT"
     And the response property "$.message" contains a user friendly text
 
+  @otp_send_code_400.7_send_code_undeclared_property
+  Scenario: Request body contains a property not declared in the schema
+    Given the request body property "$.phoneNumber" is set to config_var: "phone_number"
+    And the request body property "$.message" is set to config_var: "message"
+    And the request body includes an undeclared property "$.unexpectedParam" set to any value
+    When the HTTP "POST" request is sent
+    Then the response status code is 400
+    And the response header "x-correlator" has same value as the request header "x-correlator"
+    And the response header "Content-Type" is "application/json"
+    And the response property "$.status" is 400
+    And the response property "$.code" is "INVALID_ARGUMENT"
+    And the response property "$.message" contains a user friendly text
+
 ###########################
 #  401 errors for send-code
 ###########################
@@ -217,6 +230,19 @@ Feature: one-time-password-sms, vwip - Operation sendCode
     And the response property "$.code" is "ONE_TIME_PASSWORD_SMS.PHONE_NUMBER_BLOCKED"
     And the response property "$.message" contains a user friendly text
 
+  @otp_send_code_403.5_send_code_missing_access_token_scope
+  Scenario: Missing access token scope for send-code
+    Given the request body property "$.phoneNumber" is set to config_var: "phone_number"
+    And the request body property "$.message" is set to config_var: "message"
+    And the header "Authorization" is set to a valid access token that does not include scope one-time-password-sms:send-validate
+    When the HTTP "POST" request is sent
+    Then the response status code is 403
+    And the response header "x-correlator" has same value as the request header "x-correlator"
+    And the response header "Content-Type" is "application/json"
+    And the response property "$.status" is 403
+    And the response property "$.code" is "PERMISSION_DENIED"
+    And the response property "$.message" contains a user friendly text
+
 ###########################
 #  404 errors for send-code
 ###########################
@@ -230,5 +256,5 @@ Feature: one-time-password-sms, vwip - Operation sendCode
     And the response header "x-correlator" has same value as the request header "x-correlator"
     And the response header "Content-Type" is "application/json"
     And the response property "$.status" is 404
-    And the response property "$.code" is "NOT_FOUND"
+    And the response property "$.code" is "IDENTIFIER_NOT_FOUND"
     And the response property "$.message" contains a user friendly text

--- a/code/Test_definitions/one-time-password-sms-validateCode.feature
+++ b/code/Test_definitions/one-time-password-sms-validateCode.feature
@@ -50,7 +50,6 @@ Feature: one-time-password-sms, vwip - operation validateCode
 
 # Following error code is not managed in scenarios
 # -429 as it could not be easily tested
-# -403 as there is no valid scenario
 
 ###############################
 #  400 errors for validate-code
@@ -177,6 +176,19 @@ Feature: one-time-password-sms, vwip - operation validateCode
     And the response property "$.code" is "ONE_TIME_PASSWORD_SMS.VERIFICATION_FAILED"
     And the response property "$.message" contains a user friendly text
 
+  @otp_validate_code_400.11_validate_code_undeclared_property
+  Scenario: Request body contains a property not declared in the schema
+    Given an authenticationId has been retrieved from a send-code request
+    And the request body property "$.code" is set to the value received in the SMS
+    And the request body includes an undeclared property "$.unexpectedParam" set to any value
+    When the HTTP "POST" request is sent
+    Then the response status code is 400
+    And the response header "x-correlator" has same value as the request header "x-correlator"
+    And the response header "Content-Type" is "application/json"
+    And the response property "$.status" is 400
+    And the response property "$.code" is "INVALID_ARGUMENT"
+    And the response property "$.message" contains a user friendly text
+
 ###############################
 #  401 errors for validate-code
 ###############################
@@ -212,6 +224,23 @@ Feature: one-time-password-sms, vwip - operation validateCode
     And the response header "Content-Type" is "application/json"
     And the response property "$.status" is 401
     And the response property "$.code" is "UNAUTHENTICATED"
+    And the response property "$.message" contains a user friendly text
+
+###############################
+#  403 errors for validate-code
+###############################
+
+  @otp_validate_code_403.1_validate_code_missing_access_token_scope
+  Scenario: Missing access token scope for validate-code
+    Given an authenticationId has been retrieved from a send-code request
+    And the request body property "$.code" is set to the value received in the SMS
+    And the header "Authorization" is set to a valid access token that does not include scope one-time-password-sms:send-validate
+    When the HTTP "POST" request is sent
+    Then the response status code is 403
+    And the response header "x-correlator" has same value as the request header "x-correlator"
+    And the response header "Content-Type" is "application/json"
+    And the response property "$.status" is 403
+    And the response property "$.code" is "PERMISSION_DENIED"
     And the response property "$.message" contains a user friendly text
 
 ###############################


### PR DESCRIPTION
#### What type of PR is this?

* correction

#### What this PR does / why we need it:

Addresses the error-model and Commonalities r4.3 alignment findings from #144:

- Scoped the shared `Generic404` into a per-operation response: `SendCodeIdentifierNotFound404` (IDENTIFIER_NOT_FOUND only) on send-code, a validate-code-only NOT_FOUND response (renamed to `ValidateCodeNotFound404`) on validate-code. Fixed send-code's 404 test to expect `IDENTIFIER_NOT_FOUND`, matching Commonalities `C02.02`.
- Tightened `AuthenticationId`'s pattern to require at least 1 character (it previously accepted `""` despite being a required field).
- Declared `additionalProperties: false` on `SendCodeBody` and `ValidateCodeBody`, with a dedicated undeclared-property test for each operation.
- Dropped `OUT_OF_RANGE` from validate-code's 400 response: no field in that operation has a range constraint, so no test scenario is possible.
- Added missing-access-token-scope 403 `PERMISSION_DENIED` test scenarios for both operations (previously declared but untested).
- Added an `info.description` note that this API is two-legged only.

Kept the API-specific 403 codes (`PHONE_NUMBER_NOT_ALLOWED`, `PHONE_NUMBER_BLOCKED`) rather than moving to a generic 422 `SERVICE_NOT_APPLICABLE` — the finer-grained codes are more useful to callers, so no spec change for that item.

#### Which issue(s) this PR fixes:

Fixes #144

#### Special notes for reviewers:

Breaking change on top of the already-accepted 2.0.0 major bump: `validate-code`'s 404 no longer declares `IDENTIFIER_NOT_FOUND`, and both request bodies now reject undeclared properties.

#### Changelog input

```
 release-note
- Scope 404 responses per operation, tighten AuthenticationId pattern, reject undeclared request body properties, and add missing 403/400 test coverage
```

#### Additional documentation

This section can be blank.

```
docs

```
